### PR TITLE
Make DecNashPlanning a poetry env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,4 @@ experiments/results/
 
 # Dependencies
 poetry.lock
+Manifest.toml

--- a/.gitignore
+++ b/.gitignore
@@ -138,4 +138,4 @@ datasets/
 experiments/results/
 
 # Dependencies
-InteractionSimulator/
+poetry.lock

--- a/README.md
+++ b/README.md
@@ -4,41 +4,29 @@ Decentralized game-theoretic planning using the [INTERACTION Dataset](https://in
 Code for "Multi-Vehicle Control in Roundabouts using Decentralized Game-Theoretic Planning" at IJCAI 2021 AI4AD Workshop.
 
 ## Getting started
-Clone the DecNashPlanning repository
+
+1. Clone the DecNashPlanning repository.
 ```
 git clone https://github.com/sisl/DecNashPlanning.git
 cd DecNashPlanning
 ```
-Create and activate a conda environment with Python 3.7
-```
-conda create -y --name dnp python==3.7
-conda activate dnp
-```
-Clone InteractionSimulator and pip install the module.
-```
-git clone https://github.com/sisl/InteractionSimulator.git
-cd InteractionSimulator
-git checkout v0.0.2
-pip install -e .
-cd ..
-export PYTHONPATH=$(pwd):$PYTHONPATH
-```
-Install additional requirements
-```
-pip install -r requirements.txt
-```
-Install `ffmpeg` writer
-```
-conda install -c conda-forge ffmpeg
-```
-Copy INTERACTION Dataset files:
-The INTERACTION dataset contains a two folders which should be copied into a folder called `./InteractionSimulator/datasets`: 
-  - the contents of `recorded_trackfiles` should be copied to `./InteractionSimulator/datasets/trackfiles`
-  - the contents of `maps` should be copied to `./InteractionSimulator/datasets/maps`
 
+2. This package uses [poetry](https://python-poetry.org/) for dependency management. Once you've [setup poetry](https://python-poetry.org/docs/#installation), you can install all dependencies by running in the `./install` script.
 
+3. In order for the `InteractionSimulator` to work, you need to place your copy of the `INTERACTION Dataset` in the directory that the `INTERSIM_DATASET_DIR` environment variable points to.
+    - the contents of `recorded_trackfiles` should be copied to `$INTERSIM_DATASET_DIR/trackfiles`
+    - the contents of `maps` should be copied to `$INTERSIM_DATASET_DIR/maps`
+
+If you want to avoid setting `INTERSIM_DATASET_DIR` environment variable manually every time, you can add it to the `.env` file at the repo root which will be automatically sources upon sourcing `activate`
+```
+# .env
+export INTERSIM_DATASET_DIR=/path/to/INTERACTION/dataset/.../
+```
 
 ## Running experiments
+
+In order to run experiments, you need to activate the poetry environment. For this purpose run `source activate`.
+
 You can run all experiments to generate trajectories and videos using `python experiments/exp_wrapper.py` (which makes successive calls to `experiments/experiment.py` with appropriate settings.
 
 To calculate metrics from already generated trajectories, run `python experiments/metrics.py`.

--- a/activate
+++ b/activate
@@ -1,3 +1,5 @@
+#!/usr/bin/env sh
+
 layout_poetry() {
   if [[ ! -f pyproject.toml ]]; then
     log_error 'No pyproject.toml found. Use `poetry new` or `poetry init` to create one first.'
@@ -17,4 +19,6 @@ layout_poetry
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 export JULIA_PROJECT=$SCRIPT_DIR/src/julia/
 
-source .env
+if test -f ./.env; then
+  source ./.env
+fi

--- a/activate
+++ b/activate
@@ -1,0 +1,20 @@
+layout_poetry() {
+  if [[ ! -f pyproject.toml ]]; then
+    log_error 'No pyproject.toml found. Use `poetry new` or `poetry init` to create one first.'
+    exit 2
+  fi
+
+  # create venv if it doesn't exist
+  poetry run true
+
+  export VIRTUAL_ENV=$(poetry env info --path)
+  export POETRY_ACTIVE=1
+  source $VIRTUAL_ENV/bin/activate
+}
+
+layout_poetry
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+export JULIA_PROJECT=$SCRIPT_DIR/src/julia/
+
+source .env

--- a/experiments/animate.py
+++ b/experiments/animate.py
@@ -1,6 +1,7 @@
 # experiment.py
+import torch
 import pickle
-from intersim.datautils import *
+import intersim.datautils as utils
 from intersim import RoundaboutSimulator
 import os
 import matplotlib.animation as animation
@@ -15,29 +16,29 @@ LOCATIONS = ['DR_USA_Roundabout_FT',
 
 def animate(locnum, track, setting, frames):
     name=LOCATIONS[locnum]
-    
+
     fullname = name+'_track%03i_%s_frames%04i'%(track,setting,frames)
     outdir = './experiments/results/'
-    
+
     # load states
     states = torch.load(outdir+fullname+'_states.pt')
-    
-    # load graphs    
+
+    # load graphs
     graph_list = pickle.load(open(outdir+fullname+'_graphs.pkl', 'rb'))
-    
+
     # load lengths, widths
     lengths = torch.load(outdir+fullname+'_lengths.pt')
     widths = torch.load(outdir+fullname+'_widths.pt')
-    
-    # save animation  
+
+    # save animation
     Writer = animation.writers['ffmpeg']
     writer = Writer(fps=15, bitrate=1800)
     fig = plt.figure()
     ax = fig.gca()
-    osm = 'InteractionSimulator/datasets/maps/'+name+'.osm'
+    osm = f'{utils.DATASET_DIR}/maps/'+name+'.osm'
     av = AnimatedViz(ax, osm, states, lengths, widths, graphs=graph_list)
     ani = animation.FuncAnimation(fig, av.animate, frames=len(states),
-                    interval=20, blit=True, init_func=av.initfun, 
+                    interval=20, blit=True, init_func=av.initfun,
                     repeat=False)
     ani.save(outdir+fullname+'_ani_manual.mp4', writer)
 
@@ -50,10 +51,10 @@ if __name__ == '__main__':
                        help='track number (default 0)')
     parser.add_argument('--frames', default=1000, type=int,
                        help='number of frames (default 1000)')
-    parser.add_argument('--exp', choices=['decnash', 'cnash', 'idm'], 
+    parser.add_argument('--exp', choices=['decnash', 'cnash', 'idm'],
                         default='decnash', help='experiment')
     args = parser.parse_args()
     animate(args.loc, args.track, args.exp, args.frames)
 
-                    
+
 

--- a/install
+++ b/install
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+
+poetry install
+julia -e "import Pkg; Pkg.instantiate(); Pkg.precompile();"
+python -c "import julia; julia.install()"

--- a/install
+++ b/install
@@ -1,5 +1,7 @@
 #!/usr/bin/env sh
 
+. ./activate
+
 poetry install
 julia -e "import Pkg; Pkg.instantiate(); Pkg.precompile();"
 python -c "import julia; julia.install()"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ packages = [{ include = "src/decnash.py" }]
 python = "~3.7.1"
 julia = "^0.5.6"
 tikzplotlib = "^0.9.12"
-intersim = { git = "https://github.com/lassepe/InteractionSimulator", rev = "6b53251a67c5c5dbdafbbe0214cb0d4036c60177"}
+intersim = { git = "https://github.com/sisl/InteractionSimulator", rev = "e104ee6135503bbcea52b490ae7e63b7108e7e78"}
 
 [tool.poetry.dev-dependencies]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,19 @@
+[tool.poetry]
+name = "decnashplanning"
+version = "0.1.0"
+description = ""
+authors = ["Arec Jamgocian <jamgochian95@gmail.com>"]
+license = "MIT"
+packages = [{ include = "src/decnash.py" }]
+
+[tool.poetry.dependencies]
+python = "~3.7.1"
+julia = "^0.5.6"
+tikzplotlib = "^0.9.12"
+intersim = { git = "https://github.com/lassepe/InteractionSimulator", rev = "6b53251a67c5c5dbdafbbe0214cb0d4036c60177"}
+
+[tool.poetry.dev-dependencies]
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
-julia
-tikzplotlib
-

--- a/src/julia/Project.toml
+++ b/src/julia/Project.toml
@@ -1,0 +1,7 @@
+[deps]
+Algames = "4a64a370-b39e-4988-9b44-fc3fb6d78c25"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
+PyCall = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0"
+RobotDynamics = "38ceca67-d8d3-44e8-9852-78a5596522e1"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"


### PR DESCRIPTION
This PR makes DecNashPlanning a poetry environment and thus enables the following changes

1. InteractionSimulator is a [poetry git dependency](https://python-poetry.org/docs/dependency-specification/#git-dependencies) so that the user does not have to manually clone InteractionSimulator to  a specific directory.
**Note**: ~~Currently, this git dependency is pointing to my branch at https://github.com/lassepe/InteractionSimulator/tree/DecNashPlanning-poetry-backports for testing. This must be changed before merging (requires merging https://github.com/sisl/InteractionSimulator/pull/6 first)~~ (done)
2. Added an `install` script that wraps `poetry install` and does some house-keeping to setup pyjulia and the local Julia environment (to avoid installing Julia dependencies of this package globally)
3. Added an `activate` script that sets relevant environment variables to enable the local julia project and also activate the poetry environment. This script also sources the `.env` file at the repo root so that the user can export the `INTERSIM_DATASET_DIR` in there.

I've also updated the README accordingly.  Let me know if the instructions in there are clear.